### PR TITLE
Allow to set user_version on the generated SQLite files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,13 @@
 
 	<groupId>com.lksnext</groupId>
 	<artifactId>sqlite-builder-parent</artifactId>
-	<version>0.1.2</version>
+	<version>0.1.3</version>
 	<packaging>pom</packaging>
 	<name>SQLite Builder Parent</name>
 	<description>Parent of the SQLite Builder</description>
 
 	<properties>
-		<gson.version>2.8.5</gson.version>
+		<gson.version>2.8.7</gson.version>
 		<commonsio.version>2.8.0</commonsio.version>
 		<sqlite.jdbc.version>3.15.1</sqlite.jdbc.version>
 		<maven.assembly.plugin.version>3.0.0</maven.assembly.plugin.version>
@@ -26,7 +26,7 @@
 		<apache.commons.collection.version>3.2.2</apache.commons.collection.version>
 		<version.spring.data>1.4.1.RELEASE</version.spring.data>
 		<mockito.version>1.9.5</mockito.version>
-		<jooq.version>3.14.0</jooq.version>
+		<jooq.version>3.14.11</jooq.version>
 
 		<version.springframework>5.0.19.RELEASE</version.springframework>
 		<version.springframework.data>Kay-SR7</version.springframework.data>

--- a/sqlite-builder-api/pom.xml
+++ b/sqlite-builder-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.lksnext</groupId>
 		<artifactId>sqlite-builder-parent</artifactId>
-		<version>0.1.2</version>
+		<version>0.1.3</version>
 	</parent>
 
 	<artifactId>sqlite-builder-api</artifactId>

--- a/sqlite-builder-impl/pom.xml
+++ b/sqlite-builder-impl/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.lksnext</groupId>
 		<artifactId>sqlite-builder-parent</artifactId>
-		<version>0.1.2</version>
+		<version>0.1.3</version>
 	</parent>
 
 	<artifactId>sqlite-builder-impl</artifactId>

--- a/sqlite-builder-impl/src/main/java/com/lksnext/sqlite/impl/SQLiteDBConfigurableGeneratorImpl.java
+++ b/sqlite-builder-impl/src/main/java/com/lksnext/sqlite/impl/SQLiteDBConfigurableGeneratorImpl.java
@@ -114,6 +114,9 @@ public class SQLiteDBConfigurableGeneratorImpl implements SQLiteDBConfigurableGe
 			}
 			sqliteCon.commit();
 			SQLiteUtils.vacuum(sqliteCon);
+			if (database.getVersion() != null) {
+				SQLiteUtils.setVersion(sqliteCon, database.getVersion().intValue());	
+			}
 			sqliteCon.close();
 			availableDatabases.add(dbName);
 			dbCreationTime = System.currentTimeMillis() - dbCreationTime;

--- a/sqlite-builder-impl/src/main/java/com/lksnext/sqlite/impl/definition/DatabaseDefinition.java
+++ b/sqlite-builder-impl/src/main/java/com/lksnext/sqlite/impl/definition/DatabaseDefinition.java
@@ -9,6 +9,7 @@ public class DatabaseDefinition {
 	private String type;
 	private String _extends;
 	private String description;
+	private Integer version;
 	private List<SchemaElement> schema;
 	
 	
@@ -48,6 +49,12 @@ public class DatabaseDefinition {
 	}
 	public void setExtends(String _extends) {
 		this._extends = _extends;
+	}
+	public Integer getVersion() {
+		return version;
+	}
+	public void setVersion(Integer version) {
+		this.version = version;
 	}
 
 }

--- a/sqlite-builder-impl/src/main/java/com/lksnext/sqlite/impl/util/SQLiteUtils.java
+++ b/sqlite-builder-impl/src/main/java/com/lksnext/sqlite/impl/util/SQLiteUtils.java
@@ -106,7 +106,8 @@ public class SQLiteUtils {
 		return conn;
 
 	}
-
+	
+	
 	public static final GenericTable importData(DataSource ds, Connection sqliteConnection, String query, String table)
 			throws SQLException {
 		LOG.info("Importing {}...", table);
@@ -189,6 +190,13 @@ public class SQLiteUtils {
 		try (Statement stm = sqliteCon.createStatement()) {
 			stm.execute("PRAGMA auto_vacuum = 1");
 			stm.execute("VACUUM");
+		}
+	}
+	
+	public static final void setVersion(Connection sqliteCon, int version) throws SQLException {
+		sqliteCon.setAutoCommit(true);
+		try (Statement stm = sqliteCon.createStatement()) {
+			stm.execute("PRAGMA user_version = "+ version);
 		}
 	}
 


### PR DESCRIPTION
This PR resolves #1 

It allows to define a version integer attribute in the database definition yaml. 
This value is placed in the SQLite pragma user_version on the generated sqlite files. 